### PR TITLE
Fix/fix fastify export

### DIFF
--- a/src/export/fastify.ts
+++ b/src/export/fastify.ts
@@ -2,9 +2,21 @@ import type { TypedAPIExports } from '.';
 
 import type { FastifyInstance, FastifyRequest, RouteHandlerMethod } from 'fastify';
 import type { HttpRequestMethod } from '../interface/httpMethod';
+import type { APIImplementOption } from '../interface/api';
 
 export class TypedAPIFastify {
   constructor(public exports: TypedAPIExports<FastifyRequest>){}
+
+  private static option: APIImplementOption = {
+    incorrectTypeMessage: {
+      code: 400, 
+      data: {
+        message: 'The payload type is different from schema.',
+        error: 'Bad Request',
+        statusCode: 400,
+      },
+    },
+  };
 
   register(fastify: FastifyInstance) {
     const route = ((v: HttpRequestMethod, path: string, handler: RouteHandlerMethod) => {
@@ -16,7 +28,7 @@ export class TypedAPIFastify {
     });
     this.exports.apis.forEach(api => {
       route(api.method, api.uri, async (request, reply) => {
-        const implement = await api.processor({
+        const implement = await api.processor(TypedAPIFastify.option)({
           header: request.headers,
           remoteAddress: request.ip,
           body: request.body,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,9 @@ export class TypedHttpAPIServer<APISchemaType extends APISchema, Raw = undefined
     const types: APIExport<Raw>[] = this.implementations.map(v => ({
       uri: v.uri,
       method: v.method,
-      async processor(request) {
+      processor: option => async (request) => {
         const payload = request.body;
-        if(!v.io.request.is(payload)) return { code: 400, data: '400 Bad Request The payload type is incorrect.' };
+        if(!v.io.request.is(payload)) return option.incorrectTypeMessage;
         return HttpAPIResponse.unpack(await v.processor(new HttpAPIRequest(request), payload));
       },
     }));

--- a/src/interface/api.ts
+++ b/src/interface/api.ts
@@ -25,6 +25,9 @@ export type APIImplements<
 export type APIExport<Raw> = {
   uri: string,
   method: HttpRequestMethod,
-  processor: (request: HttpRequest<Raw>) => Promise<HttpResponse>
+  processor: (option: APIImplementOption) => (request: HttpRequest<Raw>) => Promise<HttpResponse>
 }
 
+export type APIImplementOption = {
+  incorrectTypeMessage: HttpResponse,
+};


### PR DESCRIPTION
This is a fix for this error that occurs when exporting to Fastify with the standard functionality.
```
\dist\server\index.js:26536
        const prefix = this[kRoutePrefix];
                           ^

TypeError: Cannot read properties of undefined (reading 'Symbol(fastify.routePrefix)')
    ...
```